### PR TITLE
Adding Formula for Linux

### DIFF
--- a/Formula/pubman-linux.rb
+++ b/Formula/pubman-linux.rb
@@ -1,0 +1,21 @@
+class PubmanLinux < Formula
+  desc "Draft, Track, and Publish 3D models to multiple platforms (Linux version)"
+  homepage "https://github.com/DrawnToDigital/pubman"
+  version "2025.6.1"
+  url "https://github.com/DrawnToDigital/pubman/releases/download/v#{version}/PubMan-#{version}.AppImage"
+  sha256 "b5219278ef8d8e9a0aee2f0b245038611add82d7bb55bacc0a2b98629c0dbac4"
+
+  depends_on :linux
+
+  def install
+    bin.install "PubMan-#{version}.AppImage" => "pubman"
+    chmod "+x", bin/"pubman"
+  end
+
+  def caveats
+    <<~EOS
+      PubMan has been installed as an AppImage.
+      You can run it by typing 'pubman' in your terminal.
+    EOS
+  end
+end 


### PR DESCRIPTION
This pull request introduces a new Homebrew formula for the Linux version of PubMan, a tool for managing and publishing 3D models. The formula includes metadata, installation instructions, and usage caveats.

### New Homebrew formula for PubMan (Linux version):

* [`Formula/pubman-linux.rb`](diffhunk://#diff-971a0f64f98f793a207df18a6994fe62007dac7e3d9dcc4ee9593b7349ae5ecbR1-R21): Added a new formula `PubmanLinux` to install PubMan as an AppImage for Linux users. The formula includes metadata such as description, homepage, version, download URL, and SHA256 checksum. It also defines installation steps, marks the binary as executable, and provides usage caveats.